### PR TITLE
Increasing timeout after `selectPixel`

### DIFF
--- a/minimap.impl.user.js
+++ b/minimap.impl.user.js
@@ -592,7 +592,7 @@ const { html, render } = mlp_uhtml;
               if (!arrived) {
                 resolve(arrived);
               }
-            }, 500);
+            }, 1500);
             const posChangedListener = function () {
               const coordinatesData = posParser.pos;
               if (randPixel[0] === coordinatesData.x && randPixel[1] === coordinatesData.y) {


### PR DESCRIPTION
The bot is unstable and selecting pixels during the animation. 
Increasing the timeout makes the bot more stable